### PR TITLE
optimize(timelineShow.vue): 展示不等待图片接口

### DIFF
--- a/src/components/timeline/timelineShow.vue
+++ b/src/components/timeline/timelineShow.vue
@@ -1,7 +1,7 @@
 <template>
   <ul v-if="lines.length" class="loadedTimelines" :style="showStyle">
     <li
-      v-for="(item, index) in props.lines"
+      v-for="(item, index) in renderList"
       :key="index"
       v-show="item.show && item.time - runtime > 0 - config.hold - showStyle['--tras-duration'] && item.time - runtime <= config.displayDuration"
       :class="{
@@ -12,7 +12,12 @@
     >
       <aside :style="{ right: Math.max((item.time - runtime) / config.displayDuration, 0) * 100 + '%' }"></aside>
       <section>
-        <span v-html="item.actionHTML"></span><span style="padding: 0px 1px">{{ (item.time - runtime).toFixed(1) }} </span>
+        <span class="skill" v-if="item.action">
+          <div class="skill_icon">
+            <img :style="`background-image:url(${PLACEHOLDER})`" :src="getSkillImage(item.skillName)" loading="auto" @error="onError">
+          </div>
+          <span>{{item.actionText}}</span>
+        </span><span style="padding: 0px 1px">{{ (item.time - runtime).toFixed(1) }} </span>
       </section>
     </li>
   </ul>
@@ -20,6 +25,8 @@
 
 <script lang="ts" setup>
 import { ITimelineLine, ShowStyle, TimelineConfigValues } from "@/types/timeline";
+import { parseAction } from "@/store/timeline";
+import { getActionByChineseName, getImgSrc } from "@/utils/xivapi";
 
 const props = defineProps<{
   config: TimelineConfigValues;
@@ -27,6 +34,73 @@ const props = defineProps<{
   runtime: number;
   showStyle: ShowStyle;
 }>();
+
+const PLACEHOLDER = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAADU//+x//8KcqkUmcbe/v8I1ff7///n//+l//4QibQKYpYMa5TG//+9/v/w/v+V9PUSe6sze1INOUxo+f+q9/+I9/2b//IfrNY2vLMQhKoNbpwLWo4K3vcb1vMR0e9L0+0wxeNL5+E8vdYPlLwNSncNPW0wcVRn7/pX7/kX//da7+9N7+8Eze9Pzt4LlNERnNAYqM470s00ts0gpsY8xL0WcJQSVXo4jl04hFRY+f+c9/8t7/uG7vtJ7/kl4/ZT/+4Z3uwMvec4veAhqs45y8QQjL0Ke7cztatErHaa///K9/969/8U5f815/dF5/VT5udI3ds91dpc0toNrNYsqsYJhL04uZYJU3REn2B3//+F//1y5/08/fes9/dn9/c/7/cU5/V2//OR5vOB5vO1//IzzvIc/e9e1OmA4+ds3ucIs+chwOFg5OAWuN4Jrd4NvdwqttcHjNJHzMgCbrUyraIQe5wje5gHWoQMTYQ5nm8RRFVI+/8y9P+Y9P2v7vxN2vws//kO8flV//d18/dT5/Zl//Mx4PERxvFl7+914u8TvO8Z7+6G8+pt1ekTxudP8+YAo+Jw2t5FyN0ct9adwdIlt84vrM4OqM484M1HrMQYlLxworgnkrU727I2oJwbc5wqc5Qyqo88t4osbYcfY38viXMCSm4dU2lDj1ghR1eM//8l5/8M2v8c8f179/dU9/NE3vFr4+937+0t4+lE4ecfr+Yv0uUWyNxYxthC/9RYzs4AisiCq7dQxJYtmpRGfZIvloYIZYYte2UIQlpg3vrZ8vUp/+9j9++l5O+a1up71upr7ee13OfJ3OQY2eRE799u59425Nyr0dlwydFwu85Ktc5u4ckAe8ljp74jnL0YnL0rn7g5mbg8xq1KzqtmzqgjhKUIZqU5hJ8SZowzlG4pXW4VSmMQOWMNLj/G7/fO5/NS3vMYzucQpd6A49ZaudY588JSvb1C67lKmLVGralSlKlSuYQMITGE9+8579ZS585S3r1z1r0YhL0xY3PsAq0mAAAAAXRSTlMAQObYZgAABihJREFUOMs11GVYk1EYgOHzfetg4ZL1ZOjYwG2CQ+kSlAYp6ZIQlBABxQCkpFG6BATB7u7u7u7u7jjo5fP7vs55z/nxAgCGDTMWBWmEVApVyHTVnU48fPiw/emp9VoFWcDECEUU6oNcYwB7Msx4hpvGTSgUMsnYLYkFEdGlCZsy+FqsgkwWYDAYgSCbKjL+5+5ptRgMU+CqdSyIiMjPz5ctdOa7YNsUrq5uQYprHeRsivEwCC0pmk1kJlOgaK4smL02/2A4bW71VqMmCywWq9FomwMDbwioM4YBOKDbpgCygKzQORbYJOSH0wgN5z3KJxhl8PlpaSlOciPzQDIFQnjgqwo4jgL7UlWaIDs4l/CpKfCUx+QRzqmSwkLxyoQEZx2ExsBYhKnY4uqquK5LdJTLZeW49hwLi/un4mTyVGmMSqVaZV8WEHQPvsaSgpUGYBVt2MbUVOeFSfGEbr0+u7sh8sXmGomXl9cqlaowJRNDmQFyhVMdtdjrWAuXDKOFIybH0e9Ts7P1x7hrJRJ7mxUrvLwKVar0IMwDIMK8jNFioWuErjp+Dv0DVSjsOurpbe9jYmK3wmtlmViVmE4WAgrT0VFnYWFhbjRixORyW2uP511CzFXUysauiLta6S0pq6goS0xMZwIqs3KLziUQuqR14XOsrWnPmBjMRZQ9i8vhzFntI3GaCqusbAZUQeUWl0boJq+bQ7K15R7Uurm5BTmbuBOIBiRPb0lqan09X+cYA2GjS9OgC+egMiepVJqyY8cOjZPE28cWQdg29qWb5RkuOuxpoBd0BJovnLDOFuXImpvTnPD4lLo6Jym+pqam1Jo9245dLJM3WlxvA9l3r5lvTSpn0OLluoD0GmlMjNjMDI+XpgUE1Eu9Q8PC3JUy58BrbeBuR+vW6ngPXDy/rV6elOC9apXXSjEeb5bG5wdg+S9oBihJKTO60QFutm49Phc319mFmRFHpBf7RNtE8XhqfFmKzDqJ/4svtyXiSOEjLt0Aly4kexCO51jqW62Xh9KU3jZRkwwMJqnxFcrQ5ZFvmF1dzgiRFJ50CRyPQ+hv+iz7LqKeVrOsuDGFPAMEMeDhJVZWVlz02F29volGRG2rAYo7dHOgb08DwlCaRM+OkKz8B8VWs2ZHmLBJz6525JhPIiAcQDja/ejTeYIHo3yd2m52gT1ePXh1lA0SZhUdbad0R5BjN+VHkEPgw6Pek3QPRvLkBVN8fWxmsfH4+TzekRVzEJL1arWpCZvrjtAjzXN6waOddCQuecGCCRP8NpZGh3Lg14jFYnsOgnIY6+ebRIV6hqE43P0BsJM4Nxmq7dv9/DdsiDLg2EvNYOIiIho5CNfEmig93YnIHoAcXbB9+zSYv/8GO2skcq2ZU11ditNaxJ1RtV5tuqbEtLhYiSIEcOHCu3eto0aNmjZy84YolM7wMavLzMzUvGKzi+ZP8TW1m2e6caNvGM8WXP34cfo4Q0MIz/lwUUKRY9qVK0FBbpnFs+x8fYcONZ1n6u/vry6ZABbBoBw1dqSfmoviNqfvyMqCi4Rc7amGDsIz/iPH1jqMAnt37/4PfVcjcemarHsUCpWKaUWLTkwZOnTNvI0jxxqei5gOpu/umT7uLxw63xOXocmCbF9urj7nJCf57BQI/cYaGp7btht0vu385/xM2aR41yyRSNRtGdKf+6AdVwWhg8PIW4bjvr3dC/Z2btt2pqWlxa+WHUprcr2SJbJs6A3p79/XTWckT6l1qB1rGNzT0rkE7F8S/H6bg4NDSexyFNmUickN6SW0h4SEUPsaDKpOHClpuRXc0/M+eBAu2Rvceaa2JJaERHZZ9vcPnEeQPst9+wZ24rgnYh1uB/eMn7n44X4wfPj+hzMXB9/6cTYM1/74wIG8XgKJeFEfciBvD33519jvuxaPn/lw9JDhEA4ZM3rmzMW3L3MJv/NYrMcnERJCzDnAyhsguvNib0M3evSYfxDKieN3/WTQl7FYrD0ElGZAbGc9ZS17TiNd3jV+4qCDEPyHlzlECB8jONokEg237MvTvFMI487n8ROXLoUQwIaMGYR3XpOIy/JY6+k0XlUVA7fzy1PWIeT1nc8TJy6FEoA/7DQrrfjPWbcAAAAASUVORK5CYII='
+const imageMap: Record<string, unknown> = reactive({})
+
+const renderList = computed(() => {
+  return props.lines.map((item: ITimelineLine) => {
+    const { action } = item
+    const { skillName, actionText } = parse(action)
+    return {
+      ...item,
+      skillName,
+      actionText,
+    }
+  })
+})
+
+function parse(text:string){
+  text = text.replaceAll(/^["']|["']$/g, "")
+  const items = parseAction(text);
+
+  if (!items) return {
+    skillName: '',
+    actionText: text,
+  }
+
+  let skillName = '';
+  for (const item of items) {
+    if (item.groups?.name) {
+      skillName = item.groups.name
+      text = text.replace(
+        item[0], item.groups?.repeat ? item.groups!.name : ''
+      )
+    }
+  }
+
+  return {
+    skillName,
+    actionText: text
+  }
+}
+
+/**
+ * 图片展示顺序说明：
+ * 1、初次展示兜底图
+ * 2、下载图片期间展示背景图
+ * 3、下载图片完成展示图片
+ * 4、下载图片出错展示兜底图
+ */
+function getSkillImage(name: string){
+  if(typeof imageMap[name] === 'string'){
+    return imageMap[name]
+  }
+
+  if(typeof imageMap[name] === 'undefined'){
+    //仅请求一次，无论成功失败都不会再调用
+    imageMap[name] = getActionByChineseName(name).then(res=>{
+      if(res?.Icon) getImgSrc(res.Icon).then(url=>{
+        imageMap[name] = url
+      })
+    })
+  }
+
+  return PLACEHOLDER
+}
+function onError(e: any){
+  e.target.src = PLACEHOLDER
+}
 </script>
 <style lang="scss">
 ::-webkit-scrollbar {
@@ -183,6 +257,9 @@ $trasDuration: 1;
           top: calc(4px * var(--normal-scale, $normalScale));
           left: calc(4px * var(--normal-scale, $normalScale));
           z-index: 1;
+          background-size: contain;
+          background-repeat: no-repeat;
+          background-position: 0 0;
         }
         &::after {
           content: "";

--- a/src/components/timeline/timelineShow.vue
+++ b/src/components/timeline/timelineShow.vue
@@ -14,10 +14,10 @@
       <section>
         <span class="skill" v-if="item.action">
           <div class="skill_icon">
-            <img :style="`background-image:url(${PLACEHOLDER})`" :src="getSkillImage(item.skillName)" loading="auto" @error="onError">
+            <img :style="`background-image:url(${PLACEHOLDER})`" :src="getSkillImage(item.skillName)" loading="auto" @error="onError" />
           </div>
-          <span>{{item.actionText}}</span>
-        </span><span style="padding: 0px 1px">{{ (item.time - runtime).toFixed(1) }} </span>
+          <span>{{ item.actionText }}</span> </span
+        ><span style="padding: 0px 1px">{{ (item.time - runtime).toFixed(1) }} </span>
       </section>
     </li>
   </ul>
@@ -35,44 +35,44 @@ const props = defineProps<{
   showStyle: ShowStyle;
 }>();
 
-const PLACEHOLDER = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAADU//+x//8KcqkUmcbe/v8I1ff7///n//+l//4QibQKYpYMa5TG//+9/v/w/v+V9PUSe6sze1INOUxo+f+q9/+I9/2b//IfrNY2vLMQhKoNbpwLWo4K3vcb1vMR0e9L0+0wxeNL5+E8vdYPlLwNSncNPW0wcVRn7/pX7/kX//da7+9N7+8Eze9Pzt4LlNERnNAYqM470s00ts0gpsY8xL0WcJQSVXo4jl04hFRY+f+c9/8t7/uG7vtJ7/kl4/ZT/+4Z3uwMvec4veAhqs45y8QQjL0Ke7cztatErHaa///K9/969/8U5f815/dF5/VT5udI3ds91dpc0toNrNYsqsYJhL04uZYJU3REn2B3//+F//1y5/08/fes9/dn9/c/7/cU5/V2//OR5vOB5vO1//IzzvIc/e9e1OmA4+ds3ucIs+chwOFg5OAWuN4Jrd4NvdwqttcHjNJHzMgCbrUyraIQe5wje5gHWoQMTYQ5nm8RRFVI+/8y9P+Y9P2v7vxN2vws//kO8flV//d18/dT5/Zl//Mx4PERxvFl7+914u8TvO8Z7+6G8+pt1ekTxudP8+YAo+Jw2t5FyN0ct9adwdIlt84vrM4OqM484M1HrMQYlLxworgnkrU727I2oJwbc5wqc5Qyqo88t4osbYcfY38viXMCSm4dU2lDj1ghR1eM//8l5/8M2v8c8f179/dU9/NE3vFr4+937+0t4+lE4ecfr+Yv0uUWyNxYxthC/9RYzs4AisiCq7dQxJYtmpRGfZIvloYIZYYte2UIQlpg3vrZ8vUp/+9j9++l5O+a1up71upr7ee13OfJ3OQY2eRE799u59425Nyr0dlwydFwu85Ktc5u4ckAe8ljp74jnL0YnL0rn7g5mbg8xq1KzqtmzqgjhKUIZqU5hJ8SZowzlG4pXW4VSmMQOWMNLj/G7/fO5/NS3vMYzucQpd6A49ZaudY588JSvb1C67lKmLVGralSlKlSuYQMITGE9+8579ZS585S3r1z1r0YhL0xY3PsAq0mAAAAAXRSTlMAQObYZgAABihJREFUOMs11GVYk1EYgOHzfetg4ZL1ZOjYwG2CQ+kSlAYp6ZIQlBABxQCkpFG6BATB7u7u7u7u7jjo5fP7vs55z/nxAgCGDTMWBWmEVApVyHTVnU48fPiw/emp9VoFWcDECEUU6oNcYwB7Msx4hpvGTSgUMsnYLYkFEdGlCZsy+FqsgkwWYDAYgSCbKjL+5+5ptRgMU+CqdSyIiMjPz5ctdOa7YNsUrq5uQYprHeRsivEwCC0pmk1kJlOgaK4smL02/2A4bW71VqMmCywWq9FomwMDbwioM4YBOKDbpgCygKzQORbYJOSH0wgN5z3KJxhl8PlpaSlOciPzQDIFQnjgqwo4jgL7UlWaIDs4l/CpKfCUx+QRzqmSwkLxyoQEZx2ExsBYhKnY4uqquK5LdJTLZeW49hwLi/un4mTyVGmMSqVaZV8WEHQPvsaSgpUGYBVt2MbUVOeFSfGEbr0+u7sh8sXmGomXl9cqlaowJRNDmQFyhVMdtdjrWAuXDKOFIybH0e9Ts7P1x7hrJRJ7mxUrvLwKVar0IMwDIMK8jNFioWuErjp+Dv0DVSjsOurpbe9jYmK3wmtlmViVmE4WAgrT0VFnYWFhbjRixORyW2uP511CzFXUysauiLta6S0pq6goS0xMZwIqs3KLziUQuqR14XOsrWnPmBjMRZQ9i8vhzFntI3GaCqusbAZUQeUWl0boJq+bQ7K15R7Uurm5BTmbuBOIBiRPb0lqan09X+cYA2GjS9OgC+egMiepVJqyY8cOjZPE28cWQdg29qWb5RkuOuxpoBd0BJovnLDOFuXImpvTnPD4lLo6Jym+pqam1Jo9245dLJM3WlxvA9l3r5lvTSpn0OLluoD0GmlMjNjMDI+XpgUE1Eu9Q8PC3JUy58BrbeBuR+vW6ngPXDy/rV6elOC9apXXSjEeb5bG5wdg+S9oBihJKTO60QFutm49Phc319mFmRFHpBf7RNtE8XhqfFmKzDqJ/4svtyXiSOEjLt0Aly4kexCO51jqW62Xh9KU3jZRkwwMJqnxFcrQ5ZFvmF1dzgiRFJ50CRyPQ+hv+iz7LqKeVrOsuDGFPAMEMeDhJVZWVlz02F29volGRG2rAYo7dHOgb08DwlCaRM+OkKz8B8VWs2ZHmLBJz6525JhPIiAcQDja/ejTeYIHo3yd2m52gT1ePXh1lA0SZhUdbad0R5BjN+VHkEPgw6Pek3QPRvLkBVN8fWxmsfH4+TzekRVzEJL1arWpCZvrjtAjzXN6waOddCQuecGCCRP8NpZGh3Lg14jFYnsOgnIY6+ebRIV6hqE43P0BsJM4Nxmq7dv9/DdsiDLg2EvNYOIiIho5CNfEmig93YnIHoAcXbB9+zSYv/8GO2skcq2ZU11ditNaxJ1RtV5tuqbEtLhYiSIEcOHCu3eto0aNmjZy84YolM7wMavLzMzUvGKzi+ZP8TW1m2e6caNvGM8WXP34cfo4Q0MIz/lwUUKRY9qVK0FBbpnFs+x8fYcONZ1n6u/vry6ZABbBoBw1dqSfmoviNqfvyMqCi4Rc7amGDsIz/iPH1jqMAnt37/4PfVcjcemarHsUCpWKaUWLTkwZOnTNvI0jxxqei5gOpu/umT7uLxw63xOXocmCbF9urj7nJCf57BQI/cYaGp7btht0vu385/xM2aR41yyRSNRtGdKf+6AdVwWhg8PIW4bjvr3dC/Z2btt2pqWlxa+WHUprcr2SJbJs6A3p79/XTWckT6l1qB1rGNzT0rkE7F8S/H6bg4NDSexyFNmUickN6SW0h4SEUPsaDKpOHClpuRXc0/M+eBAu2Rvceaa2JJaERHZZ9vcPnEeQPst9+wZ24rgnYh1uB/eMn7n44X4wfPj+hzMXB9/6cTYM1/74wIG8XgKJeFEfciBvD33519jvuxaPn/lw9JDhEA4ZM3rmzMW3L3MJv/NYrMcnERJCzDnAyhsguvNib0M3evSYfxDKieN3/WTQl7FYrD0ElGZAbGc9ZS17TiNd3jV+4qCDEPyHlzlECB8jONokEg237MvTvFMI487n8ROXLoUQwIaMGYR3XpOIy/JY6+k0XlUVA7fzy1PWIeT1nc8TJy6FEoA/7DQrrfjPWbcAAAAASUVORK5CYII='
-const imageMap: Record<string, unknown> = reactive({})
+const PLACEHOLDER =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAADU//+x//8KcqkUmcbe/v8I1ff7///n//+l//4QibQKYpYMa5TG//+9/v/w/v+V9PUSe6sze1INOUxo+f+q9/+I9/2b//IfrNY2vLMQhKoNbpwLWo4K3vcb1vMR0e9L0+0wxeNL5+E8vdYPlLwNSncNPW0wcVRn7/pX7/kX//da7+9N7+8Eze9Pzt4LlNERnNAYqM470s00ts0gpsY8xL0WcJQSVXo4jl04hFRY+f+c9/8t7/uG7vtJ7/kl4/ZT/+4Z3uwMvec4veAhqs45y8QQjL0Ke7cztatErHaa///K9/969/8U5f815/dF5/VT5udI3ds91dpc0toNrNYsqsYJhL04uZYJU3REn2B3//+F//1y5/08/fes9/dn9/c/7/cU5/V2//OR5vOB5vO1//IzzvIc/e9e1OmA4+ds3ucIs+chwOFg5OAWuN4Jrd4NvdwqttcHjNJHzMgCbrUyraIQe5wje5gHWoQMTYQ5nm8RRFVI+/8y9P+Y9P2v7vxN2vws//kO8flV//d18/dT5/Zl//Mx4PERxvFl7+914u8TvO8Z7+6G8+pt1ekTxudP8+YAo+Jw2t5FyN0ct9adwdIlt84vrM4OqM484M1HrMQYlLxworgnkrU727I2oJwbc5wqc5Qyqo88t4osbYcfY38viXMCSm4dU2lDj1ghR1eM//8l5/8M2v8c8f179/dU9/NE3vFr4+937+0t4+lE4ecfr+Yv0uUWyNxYxthC/9RYzs4AisiCq7dQxJYtmpRGfZIvloYIZYYte2UIQlpg3vrZ8vUp/+9j9++l5O+a1up71upr7ee13OfJ3OQY2eRE799u59425Nyr0dlwydFwu85Ktc5u4ckAe8ljp74jnL0YnL0rn7g5mbg8xq1KzqtmzqgjhKUIZqU5hJ8SZowzlG4pXW4VSmMQOWMNLj/G7/fO5/NS3vMYzucQpd6A49ZaudY588JSvb1C67lKmLVGralSlKlSuYQMITGE9+8579ZS585S3r1z1r0YhL0xY3PsAq0mAAAAAXRSTlMAQObYZgAABihJREFUOMs11GVYk1EYgOHzfetg4ZL1ZOjYwG2CQ+kSlAYp6ZIQlBABxQCkpFG6BATB7u7u7u7u7jjo5fP7vs55z/nxAgCGDTMWBWmEVApVyHTVnU48fPiw/emp9VoFWcDECEUU6oNcYwB7Msx4hpvGTSgUMsnYLYkFEdGlCZsy+FqsgkwWYDAYgSCbKjL+5+5ptRgMU+CqdSyIiMjPz5ctdOa7YNsUrq5uQYprHeRsivEwCC0pmk1kJlOgaK4smL02/2A4bW71VqMmCywWq9FomwMDbwioM4YBOKDbpgCygKzQORbYJOSH0wgN5z3KJxhl8PlpaSlOciPzQDIFQnjgqwo4jgL7UlWaIDs4l/CpKfCUx+QRzqmSwkLxyoQEZx2ExsBYhKnY4uqquK5LdJTLZeW49hwLi/un4mTyVGmMSqVaZV8WEHQPvsaSgpUGYBVt2MbUVOeFSfGEbr0+u7sh8sXmGomXl9cqlaowJRNDmQFyhVMdtdjrWAuXDKOFIybH0e9Ts7P1x7hrJRJ7mxUrvLwKVar0IMwDIMK8jNFioWuErjp+Dv0DVSjsOurpbe9jYmK3wmtlmViVmE4WAgrT0VFnYWFhbjRixORyW2uP511CzFXUysauiLta6S0pq6goS0xMZwIqs3KLziUQuqR14XOsrWnPmBjMRZQ9i8vhzFntI3GaCqusbAZUQeUWl0boJq+bQ7K15R7Uurm5BTmbuBOIBiRPb0lqan09X+cYA2GjS9OgC+egMiepVJqyY8cOjZPE28cWQdg29qWb5RkuOuxpoBd0BJovnLDOFuXImpvTnPD4lLo6Jym+pqam1Jo9245dLJM3WlxvA9l3r5lvTSpn0OLluoD0GmlMjNjMDI+XpgUE1Eu9Q8PC3JUy58BrbeBuR+vW6ngPXDy/rV6elOC9apXXSjEeb5bG5wdg+S9oBihJKTO60QFutm49Phc319mFmRFHpBf7RNtE8XhqfFmKzDqJ/4svtyXiSOEjLt0Aly4kexCO51jqW62Xh9KU3jZRkwwMJqnxFcrQ5ZFvmF1dzgiRFJ50CRyPQ+hv+iz7LqKeVrOsuDGFPAMEMeDhJVZWVlz02F29volGRG2rAYo7dHOgb08DwlCaRM+OkKz8B8VWs2ZHmLBJz6525JhPIiAcQDja/ejTeYIHo3yd2m52gT1ePXh1lA0SZhUdbad0R5BjN+VHkEPgw6Pek3QPRvLkBVN8fWxmsfH4+TzekRVzEJL1arWpCZvrjtAjzXN6waOddCQuecGCCRP8NpZGh3Lg14jFYnsOgnIY6+ebRIV6hqE43P0BsJM4Nxmq7dv9/DdsiDLg2EvNYOIiIho5CNfEmig93YnIHoAcXbB9+zSYv/8GO2skcq2ZU11ditNaxJ1RtV5tuqbEtLhYiSIEcOHCu3eto0aNmjZy84YolM7wMavLzMzUvGKzi+ZP8TW1m2e6caNvGM8WXP34cfo4Q0MIz/lwUUKRY9qVK0FBbpnFs+x8fYcONZ1n6u/vry6ZABbBoBw1dqSfmoviNqfvyMqCi4Rc7amGDsIz/iPH1jqMAnt37/4PfVcjcemarHsUCpWKaUWLTkwZOnTNvI0jxxqei5gOpu/umT7uLxw63xOXocmCbF9urj7nJCf57BQI/cYaGp7btht0vu385/xM2aR41yyRSNRtGdKf+6AdVwWhg8PIW4bjvr3dC/Z2btt2pqWlxa+WHUprcr2SJbJs6A3p79/XTWckT6l1qB1rGNzT0rkE7F8S/H6bg4NDSexyFNmUickN6SW0h4SEUPsaDKpOHClpuRXc0/M+eBAu2Rvceaa2JJaERHZZ9vcPnEeQPst9+wZ24rgnYh1uB/eMn7n44X4wfPj+hzMXB9/6cTYM1/74wIG8XgKJeFEfciBvD33519jvuxaPn/lw9JDhEA4ZM3rmzMW3L3MJv/NYrMcnERJCzDnAyhsguvNib0M3evSYfxDKieN3/WTQl7FYrD0ElGZAbGc9ZS17TiNd3jV+4qCDEPyHlzlECB8jONokEg237MvTvFMI487n8ROXLoUQwIaMGYR3XpOIy/JY6+k0XlUVA7fzy1PWIeT1nc8TJy6FEoA/7DQrrfjPWbcAAAAASUVORK5CYII=";
+const imageMap: Record<string, unknown> = reactive({});
 
 const renderList = computed(() => {
   return props.lines.map((item: ITimelineLine) => {
-    const { action } = item
-    const { skillName, actionText } = parse(action)
+    const { action } = item;
+    const { skillName, actionText } = parse(action);
     return {
       ...item,
       skillName,
       actionText,
-    }
-  })
-})
+    };
+  });
+});
 
-function parse(text:string){
-  text = text.replaceAll(/^["']|["']$/g, "")
+function parse(text: string) {
+  text = text.replaceAll(/^["']|["']$/g, "");
   const items = parseAction(text);
 
-  if (!items) return {
-    skillName: '',
-    actionText: text,
-  }
+  if (!items)
+    return {
+      skillName: "",
+      actionText: text,
+    };
 
-  let skillName = '';
+  let skillName = "";
   for (const item of items) {
     if (item.groups?.name) {
-      skillName = item.groups.name
-      text = text.replace(
-        item[0], item.groups?.repeat ? item.groups!.name : ''
-      )
+      skillName = item.groups.name;
+      text = text.replace(item[0], item.groups?.repeat ? item.groups!.name : "");
     }
   }
 
   return {
     skillName,
-    actionText: text
-  }
+    actionText: text,
+  };
 }
 
 /**
@@ -82,24 +82,25 @@ function parse(text:string){
  * 3、下载图片完成展示图片
  * 4、下载图片出错展示兜底图
  */
-function getSkillImage(name: string){
-  if(typeof imageMap[name] === 'string'){
-    return imageMap[name]
+function getSkillImage(name: string) {
+  if (typeof imageMap[name] === "string") {
+    return imageMap[name];
   }
 
-  if(typeof imageMap[name] === 'undefined'){
+  if (typeof imageMap[name] === "undefined") {
     //仅请求一次，无论成功失败都不会再调用
-    imageMap[name] = getActionByChineseName(name).then(res=>{
-      if(res?.Icon) getImgSrc(res.Icon).then(url=>{
-        imageMap[name] = url
-      })
-    })
+    imageMap[name] = getActionByChineseName(name).then((res) => {
+      if (res?.Icon)
+        getImgSrc(res.Icon).then((url) => {
+          imageMap[name] = url;
+        });
+    });
   }
 
-  return PLACEHOLDER
+  return PLACEHOLDER;
 }
-function onError(e: any){
-  e.target.src = PLACEHOLDER
+function onError(e: any) {
+  e.target.src = PLACEHOLDER;
 }
 </script>
 <style lang="scss">

--- a/src/components/timeline/timelineShow.vue
+++ b/src/components/timeline/timelineShow.vue
@@ -82,9 +82,9 @@ function parse(text: string) {
  * 3、下载图片完成展示图片
  * 4、下载图片出错展示兜底图
  */
-function getSkillImage(name: string) {
+function getSkillImage(name: string): string {
   if (typeof imageMap[name] === "string") {
-    return imageMap[name];
+    return imageMap[name] as string;
   }
 
   if (typeof imageMap[name] === "undefined") {
@@ -93,6 +93,7 @@ function getSkillImage(name: string) {
       if (res?.Icon)
         getImgSrc(res.Icon).then((url) => {
           imageMap[name] = url;
+          return imageMap[name];
         });
     });
   }

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -15,7 +15,7 @@ export interface ITimelineCondition {
 
 export interface ITimelineLine {
   time: number;
-  actionHTML: string;
+  action: string;
   sync?: RegExp;
   show: boolean;
   windowBefore: number;


### PR DESCRIPTION
cafe 接口服务不稳定，可能长时间不返回数据。
改为时间轴展示不依赖图片接口。

移除`parseActionHTML`。下载图片完成后，利用vue响应式，更新界面。